### PR TITLE
增加路径创建，代码run_spider传递参数错误

### DIFF
--- a/src/tianditu/ez_tdt_title_download.py
+++ b/src/tianditu/ez_tdt_title_download.py
@@ -112,4 +112,11 @@ def run_spider(z, minx, maxx, miny, maxy):
 
 
 if __name__ == '__main__':
-    run_spider(z=18, minx=120.25871185675187, maxx=120.259, miny=30.16739619707534, maxy=30.16741)
+     if os.path.exists(BASE_PATH)==False:
+        os.mkdir(BASE_PATH)
+
+    if os.path.exists(BASE_PATH_res) == False:
+        os.mkdir(BASE_PATH_res)
+
+    #run_spider(z=6, minx=120.25871185675187, maxx=120.259, miny=30.16739619707534, maxy=30.16741)
+    run_spider(z=14, minx=116.55, maxx=116.66, miny=39.94, maxy=39.91)


### PR DESCRIPTION
  run_spider(z=14, minx=116.55, maxx=116.66, miny=39.94, maxy=39.91)
此处miny 应该大于maxy,否则无法下载图片
增加创建路径：
 if os.path.exists(BASE_PATH)==False:
        os.mkdir(BASE_PATH)

    if os.path.exists(BASE_PATH_res) == False:
        os.mkdir(BASE_PATH_res)